### PR TITLE
add report fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 - **refresh_token**: Refresh token to get access token.  (string, required)
 - **servers**: Servers of API. It is different for YSS and YDN. (string, required)
 - **account_id**: Yahoo account id. (string, required)
-- **report_type**: YSS and stats of YDN report type. It is required only to use YSS. (string, default: `null`)
+- **report_type**: YSS and stats of YDN report type. It is required when use YSS and stats of YDN. (string, default: `null`)
 - **start_date**: Report start date. format:`YYYYMMDD` (string, required)
 - **end_date**: Report end date. format:`YYYYMMDD` (string, required)
 - **columns**: Report columns. (string, required)

--- a/lib/embulk/input/yahoo_ads_api/column.rb
+++ b/lib/embulk/input/yahoo_ads_api/column.rb
@@ -114,10 +114,15 @@ module Embulk
             {:request_name=>"VIEWABLE_IMPS_RATE", :api_name=>"ビューアブルインプレッション率"},
             {:request_name=>"VIEWABLE_CLICK_RATE", :api_name=>"ビューアブルクリック率"},
             {:request_name=>"VIDEO_VIEWS_TO_10_SEC", :api_name=>"動画の10秒再生数"},
+            {:request_name=>"IMPRESSION_SHARE", :api_name=>"インプレッションシェア"},
+            {:request_name=>"IMPRESSION_SHARE_BUDGET_LOSS", :api_name=>"インプレッションシェア損失率（予算）"},
+            {:request_name=>"IMPRESSION_SHARE_RANK_LOSS", :api_name=>"インプレッションシェア損失率（ランク）"},
           ]
         end
         def self.account
           [
+            {:request_name=>"ACCOUNT_ID", :api_name=>"アカウントID"},
+            {:request_name=>"ACCOUNT_NAME", :api_name=>"アカウント名"},
             {:request_name=>"COST", :api_name=>"コスト"},
             {:request_name=>"IMPS", :api_name=>"インプレッション数"},
             {:request_name=>"CLICKS", :api_name=>"クリック数"},
@@ -160,6 +165,8 @@ module Embulk
         end
         def self.campaign
           [
+            {:request_name=>"ACCOUNT_ID", :api_name=>"アカウントID"},
+            {:request_name=>"ACCOUNT_NAME", :api_name=>"アカウント名"},
             {:request_name=>"CAMPAIGN_ID", :api_name=>"キャンペーンID"},
             {:request_name=>"CAMPAIGN_NAME", :api_name=>"キャンペーン名"},
             {:request_name=>"CAMPAIGN_DISTRIBUTION_SETTINGS", :api_name=>"キャンペーン配信設定"},
@@ -229,6 +236,8 @@ module Embulk
         end
         def self.adgroup
           [
+            {:request_name=>"ACCOUNT_ID", :api_name=>"アカウントID"},
+            {:request_name=>"ACCOUNT_NAME", :api_name=>"アカウント名"},
             {:request_name=>"CAMPAIGN_ID", :api_name=>"キャンペーンID"},
             {:request_name=>"ADGROUP_ID", :api_name=>"広告グループID"},
             {:request_name=>"CAMPAIGN_NAME", :api_name=>"キャンペーン名"},
@@ -290,6 +299,8 @@ module Embulk
         end
         def self.ad
           [
+            {:request_name=>"ACCOUNT_ID", :api_name=>"アカウントID"},
+            {:request_name=>"ACCOUNT_NAME", :api_name=>"アカウント名"},
             {:request_name=>"CAMPAIGN_ID", :api_name=>"キャンペーンID"},
             {:request_name=>"ADGROUP_ID", :api_name=>"広告グループID"},
             {:request_name=>"AD_ID", :api_name=>"広告ID"},
@@ -356,6 +367,8 @@ module Embulk
         end
         def self.keywords
           [
+            {:request_name=>"ACCOUNT_ID", :api_name=>"アカウントID"},
+            {:request_name=>"ACCOUNT_NAME", :api_name=>"アカウント名"},
             {:request_name=>"CAMPAIGN_ID", :api_name=>"キャンペーンID"},
             {:request_name=>"ADGROUP_ID", :api_name=>"広告グループID"},
             {:request_name=>"KEYWORD_ID", :api_name=>"キーワードID"},
@@ -483,6 +496,9 @@ module Embulk
             {:request_name=>"VIDEO_VIEWS_TO_10_SEC", :api_name=>"videoViewsTo10Sec"},
             {:request_name=>"AVG_PERCENT_VIDEO_VIEWED", :api_name=>"averageRateVideoViewed"},
             {:request_name=>"AVG_DURATION_VIDEO_VIEWED", :api_name=>"averageDurationVideoViewed"},
+            {:request_name=>"IMPRESSION_SHARE", :api_name=>"impressionShare"},
+            {:request_name=>"IMPRESSION_SHARE_BUDGET_LOSS", :api_name=>"budgetImpressionShareLostRate"},
+            {:request_name=>"IMPRESSION_SHARE_RANK_LOSS", :api_name=>"rankImpressionShareLostRate"},
           ]
         end
       end

--- a/lib/embulk/input/yahoo_ads_api/version.rb
+++ b/lib/embulk/input/yahoo_ads_api/version.rb
@@ -1,7 +1,7 @@
 module Embulk
   module Input
       module YahooAdsApi
-        VERSION = "0.2.3"
+        VERSION = "0.2.4"
       end
   end
 end


### PR DESCRIPTION
### 概要
Yahoo!広告 API正式版リリースで追加されたフィールドを反映したいです。
https://ads-developers.yahoo.co.jp/developercenter/ja/announcement/192096.html

### 確認
今回追加したカラム（以下ではACCOUNT_NAME）をcolumnsに指定してレスポンス取得できることを確認（ads_displayに対しても同様にして確認）
```bash
$ cat config.yml

in:
  type: yahoo_ads_api
  target: report
  client_id: <client id>
  client_secret: <client secret>
  refresh_token: <refresh token>
  servers: https://ads-search.yahooapis.jp/api/v1
  account_id: <account id>
  report_type: KEYWORDS
  start_date: 20191201
  end_date: 20191231
  columns:
    - {name: ACCOUNT_NAME, type: string}
    - {name: KEYWORD_ID, type: long}
    - {name: KEYWORD, type: string}
    - {name: DAY, type: timestamp, format: "%Y-%m-%d"}
out: {type: stdout}

$ embulk preview -b <embulk bundle dir> config.yml
...(中略)...
+---------------------+-----------------+---------------------+-------------------------+
| ACCOUNT_NAME:string | KEYWORD_ID:long |      KEYWORD:string |           DAY:timestamp |
+---------------------+-----------------+---------------------+-------------------------+
...
```