### PR TITLE
API アップデート v1 -> v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 ## Overview
 
-* **Plugin type**: input
-* **Resume supported**: no
-* **Cleanup supported**: no
-* **Guess supported**: no
+- **Plugin type**: input
+- **Resume supported**: no
+- **Cleanup supported**: no
+- **Guess supported**: no
 
 ## Configuration
 
 - **target**: Select `report` or `stats` (string, default: `report`)
 - **client_id**: Yahoo client ID. (string, required)
 - **client_secret**: Yahoo client secret. (string, required)
-- **refresh_token**: Refresh token to get access token.  (string, required)
-- **servers**: Servers of API. It is different for YSS and YDN. (string, required)
+- **refresh_token**: Refresh token to get access token. (string, required)
+- **ads_type**: Select `yss` or `ydn` (string, required)
 - **account_id**: Yahoo account id. (string, required)
 - **report_type**: YSS and stats of YDN report type. It is required when use YSS and stats of YDN. (string, default: `null`)
 - **start_date**: Report start date. format:`YYYYMMDD` (string, required)
@@ -32,21 +32,19 @@ in:
   client_id: xxxxxx
   client_secret: yyyyyy
   refresh_token: zzzzzz
-  servers: https://ads-xxx.yahooapis.jp/api/vX
+  ads_type: yss
   account_id: 00000000
   report_type: CAMPAIGN
   start_date: 20191205
   end_date: 20191212
   columns:
-    - {name: CAMPAIGN_ID, type: long}
-    - {name: CAMPAIGN_NAME, type: string}
-    - {name: DAY, type: timestamp, format: "%Y-%m-%d"}
+    - { name: CAMPAIGN_ID, type: long }
+    - { name: CAMPAIGN_NAME, type: string }
+    - { name: DAY, type: timestamp, format: "%Y-%m-%d" }
 ```
-
 
 ## Build
 
 ```
 $ rake
 ```
-

--- a/lib/embulk/input/yahoo_ads_api/client.rb
+++ b/lib/embulk/input/yahoo_ads_api/client.rb
@@ -1,11 +1,16 @@
-require 'rest-client'
-require 'date'
-require 'securerandom'
+require "rest-client"
+require "date"
+require "securerandom"
 
 module Embulk
   module Input
     module YahooAdsApi
       class Client
+        SERVERS = {
+          yss: "https://ads-search.yahooapis.jp/api/v4",
+          ydn: "https://ads-display.yahooapis.jp/api/v4",
+        }
+
         def initialize(account_id, token)
           @account_id = account_id
           @token = token
@@ -20,8 +25,9 @@ module Embulk
             {
               content_type: :json,
               accept: :json,
-              Authorization: "bearer #{@token}"
-            }).body
+              Authorization: "bearer #{@token}",
+            }
+          ).body
         end
 
         def temporarily_download(method, params)
@@ -29,23 +35,23 @@ module Embulk
           ::Embulk.logger.info "Access URI: #{url}"
           path = "./tmp/embulk-#{Date.today}/"
           FileUtils.mkdir_p(path)
-          file_path = path+"#{SecureRandom.hex(10)}"
-          File.open(file_path, 'w') {|f|
+          file_path = path + "#{SecureRandom.hex(10)}"
+          File.open(file_path, "w") { |f|
             block = proc { |response|
               response.read_body do |chunk|
                 f.write chunk
               end
             }
             RestClient::Request.execute(
-             method: :post,
-             url: url,
-             payload: params,
-             headers: {
-               content_type: :json,
-               accept: :json,
-               Authorization: "bearer #{@token}"
-             },
-             block_response: block
+              method: :post,
+              url: url,
+              payload: params,
+              headers: {
+                content_type: :json,
+                accept: :json,
+                Authorization: "bearer #{@token}",
+              },
+              block_response: block,
             )
           }
           file_path

--- a/lib/embulk/input/yahoo_ads_api/config_check.rb
+++ b/lib/embulk/input/yahoo_ads_api/config_check.rb
@@ -6,10 +6,10 @@ module Embulk
           if config["target"] != "report" && config["target"] != "stats"
             raise ::Embulk::Input::YahooAdsApi::Error::WrongConfigError, "Invalid value in target."
           end
-          if config["target"] == "stats" && config["servers"].include?("search")
+          if config["target"] == "stats" && config["ads_type"] == "yss"
             raise ::Embulk::Input::YahooAdsApi::Error::WrongConfigError, "Stats is not supported in YSS."
           end
-          if (config["target"] == "stats" || config["servers"].include?("search")) && config["report_type"].nil?
+          if (config["target"] == "stats" || config["ads_type"] == "yss") && config["report_type"].nil?
             raise ::Embulk::Input::YahooAdsApi::Error::WrongConfigError, "report_type must be filled."
           end
         end
@@ -17,4 +17,3 @@ module Embulk
     end
   end
 end
-  

--- a/lib/embulk/input/yahoo_ads_api/plugin.rb
+++ b/lib/embulk/input/yahoo_ads_api/plugin.rb
@@ -1,4 +1,4 @@
-require 'time'
+require "time"
 
 module Embulk
   module Input
@@ -13,7 +13,7 @@ module Embulk
             :client_id => config.param("client_id", :string),
             :client_secret => config.param("client_secret", :string),
             :refresh_token => config.param("refresh_token", :string),
-            :servers => config.param("servers", :string),
+            :ads_type => config.param("ads_type", :string),
             :columns => config.param("columns", :array),
             :account_id => config.param("account_id", :string),
             :report_type => config.param("report_type", :string, default: nil),

--- a/lib/embulk/input/yahoo_ads_api/report_client.rb
+++ b/lib/embulk/input/yahoo_ads_api/report_client.rb
@@ -1,12 +1,12 @@
-require 'json'
+require "json"
 
 module Embulk
   module Input
     module YahooAdsApi
       class ReportClient < Client
-        def initialize(servers, account_id, token)
+        def initialize(ads_type, account_id, token)
           super(account_id, token)
-          @base = servers + '/ReportDefinitionService/'
+          @base = SERVERS[ads_type.to_sym] + "/ReportDefinitionService/"
         end
 
         def run(query)
@@ -20,8 +20,8 @@ module Embulk
         end
 
         def columns(type)
-          params = yss? ? { reportType: type } : { type: 'AD' }
-          response = self.invoke('getReportFields', params.to_json )
+          params = yss? ? { reportType: type } : { type: "AD" }
+          response = self.invoke("getReportFields", params.to_json)
           columns = JSON.parse(response, symbolize_names: true)[:rval][:fields].map do |field|
             { request_name: field[:fieldName], api_name: field[:displayFieldNameJA] }
           end
@@ -29,50 +29,31 @@ module Embulk
         end
 
         def yss?
-          @base.include? 'search'
+          @base.include? "search"
         end
 
         private
+
         def add_report(config)
-          column_name_list = config[:fields].map {|field| field["name"]}
-          if config[:servers].include?("display")
-            add_config = {
-              accountId: @account_id,
-              operand: [
-                {
-                  dateRange: {
-                    endDate: config[:end_date],
-                    startDate: config[:start_date]
-                  },
-                  dateRangeType: config[:date_range_type],
-                  downloadEncode: "UTF-8",
-                  downloadFormat: "CSV",
-                  fields: column_name_list,
-                  lang: "JA",
-                  reportName: "YahooReport_#{DateTime.now.strftime("%Y%m%d_%H%I%s")}",
-                }
-              ]
-            }.to_json
-          elsif config[:servers].include?("search")
-            add_config = {
-              accountId: @account_id,
-              operand: [
-                {
-                  dateRange: {
-                      endDate: config[:end_date],
-                      startDate: config[:start_date]
-                  },
-                  fields: column_name_list,
-                  reportDateRangeType: config[:date_range_type],
-                  reportDownloadEncode: "UTF-8",
-                  reportDownloadFormat: "CSV",
-                  reportLanguage: "JA",
-                  reportName: "YahooReport_#{DateTime.now.strftime("%Y%m%d_%H%I%s")}",
-                  reportType: config[:report_type],
-                }
-              ]
-            }.to_json
-          end
+          column_name_list = config[:fields].map { |field| field["name"] }
+          add_config = {
+            accountId: @account_id,
+            operand: [
+              {
+                dateRange: {
+                  endDate: config[:end_date],
+                  startDate: config[:start_date],
+                },
+                fields: column_name_list,
+                reportDateRangeType: config[:date_range_type],
+                reportDownloadEncode: "UTF8",
+                reportDownloadFormat: "CSV",
+                reportLanguage: "JA",
+                reportName: "YahooReport_#{DateTime.now.strftime("%Y%m%d_%H%I%s")}",
+                reportType: config[:ads_type] == "yss" ? config[:report_type] : nil,
+              }.reject { |_k, v| v.nil? },
+            ],
+          }.to_json
           response = JSON.parse(self.invoke("add", add_config))
           if response["rval"]["values"][0]["operationSucceeded"] == false
             error = response["rval"]["values"][0]["errors"]
@@ -84,10 +65,10 @@ module Embulk
         def report_download(report_job_id, wait_second = 5)
           download_config = {
             accountId: @account_id,
-            reportJobId: report_job_id
+            reportJobId: report_job_id,
           }.to_json
           sleep(wait_second)
-          file_path = self.temporarily_download('download', download_config)
+          file_path = self.temporarily_download("download", download_config)
           if json_response?(file_path)
             ::Embulk.logger.info "Waiting For Making Report"
             return report_download(report_job_id, wait_second * 2)
@@ -102,18 +83,18 @@ module Embulk
             operand: [
               {
                 reportJobId: report_id,
-              }
-            ]
+              },
+            ],
           }.to_json
-          self.invoke('remove', remove_config)
+          self.invoke("remove", remove_config)
         end
 
         def json_response?(file_path)
           left_flag = false; right_flag = false
           File.open(file_path) do |file|
             file.each_line.with_index do |line, i|
-              left_flag = true if i == 0 && line.start_with?('{')
-              right_flag = true if file.eof? && line.end_with?('}')
+              left_flag = true if i == 0 && line.start_with?("{")
+              right_flag = true if file.eof? && line.end_with?("}")
             end
           end
           return left_flag && right_flag

--- a/lib/embulk/input/yahoo_ads_api/stats_client.rb
+++ b/lib/embulk/input/yahoo_ads_api/stats_client.rb
@@ -1,106 +1,108 @@
-require 'json'
+require "json"
+
 module Embulk
   module Input
     module YahooAdsApi
       class StatsClient < Client
         STAT_COLUMNS = [
-          {:request_name=>"CAMPAIGN_ID", :api_name=>"campaignId"},
-            {:request_name=>"CAMPAIGN_NAME", :api_name=>"campaignName"},
-            {:request_name=>"ADGROUP_ID", :api_name=>"adGroupId"},
-            {:request_name=>"ADGROUP_NAME", :api_name=>"adGroupName"},
-            {:request_name=>"AD_ID", :api_name=>"adId"},
-            {:request_name=>"AD_NAME", :api_name=>"adName"},
-            {:request_name=>"IMPS", :api_name=>"imps"},
-            {:request_name=>"IMPS_PREV", :api_name=>"impsPrev"},
-            {:request_name=>"CLICK", :api_name=>"clickCnt"},
-            {:request_name=>"CLICK_RATE", :api_name=>"clickRate"},
-            {:request_name=>"CLICK_RATE_PREV", :api_name=>"clickRatePrev"},
-            {:request_name=>"COST", :api_name=>"cost"},
-            {:request_name=>"AVG_CPC", :api_name=>"avgCpc"},
-            {:request_name=>"CONVERSIONS", :api_name=>"conversions"},
-            {:request_name=>"CONV_RATE", :api_name=>"conversionRate"},
-            {:request_name=>"CONVERSIONS_VIA_AD_CLICK", :api_name=>"conversionsViaAdClick"},
-            {:request_name=>"CONVERSION_RATE_VIA_AD_CLICK", :api_name=>"conversionRateViaAdClick"},
-            {:request_name=>"ALL_CONV", :api_name=>"allConversions"},
-            {:request_name=>"ALL_CONV_RATE", :api_name=>"allConversionRate"},
-            {:request_name=>"COST_PER_CONV", :api_name=>"cpa"},
-            {:request_name=>"CONV_VALUE", :api_name=>"conversionValue"},
-            {:request_name=>"VALUE_PER_CONV", :api_name=>"valuePerConversions"},
-            {:request_name=>"CONV_VALUE_PER_COST", :api_name=>"convValuePerCost"},
-            {:request_name=>"ALL_CONV_VALUE_PER_COST", :api_name=>"allConvValuePerCost"},
-            {:request_name=>"CONV_VALUE_VIA_AD_CLICK_PER_COST", :api_name=>"convValueViaAdClickPerCost"},
-            {:request_name=>"ALL_CONV_VALUE", :api_name=>"allConversionValue"},
-            {:request_name=>"VALUE_PER_ALL_CONV", :api_name=>"valuePerAllConversions"},
-            {:request_name=>"CONV_VALUE_VIA_AD_CLICK", :api_name=>"conversionValueViaAdClick"},
-            {:request_name=>"VALUE_PER_CONV_VIA_AD_CLICK", :api_name=>"valuePerConversionsViaAdClick"},
-            {:request_name=>"COST_PER_CONV_VIA_AD_CLICK", :api_name=>"cpaViaAdClick"},
-            {:request_name=>"COST_PER_ALL_CONV", :api_name=>"allCpa"},
-            {:request_name=>"CROSS_DEVICE_CONVERSIONS", :api_name=>"crossDeviceConversions"},
-            {:request_name=>"AVG_DELIVER_RANK", :api_name=>"avgDeliverRank"},
-            {:request_name=>"MEASURED_IMPS", :api_name=>"measuredImps"},
-            {:request_name=>"TOTAL_VIEWABLE_IMPS", :api_name=>"totalVimps"},
-            {:request_name=>"MEASURED_IMPS_RATE", :api_name=>"measuredImpsRate"},
-            {:request_name=>"VIEWABLE_IMPS", :api_name=>"vimps"},
-            {:request_name=>"VIEWABLE_IMPS_RATE", :api_name=>"viewableImpsRate"},
-            {:request_name=>"INVIEW_RATE", :api_name=>"inViewRate"},
-            {:request_name=>"VIEWABLE_CLICK", :api_name=>"viewableClicks"},
-            {:request_name=>"INVIEW_CLICK", :api_name=>"inViewClickCnt"},
-            {:request_name=>"VIEWABLE_CLICK_RATE", :api_name=>"viewableClickRate"},
-            {:request_name=>"INVIEW_CLICK_RATE", :api_name=>"inViewClickRate"},
-            {:request_name=>"PAID_VIDEO_VIEWS", :api_name=>"paidVideoViews"},
-            {:request_name=>"PAID_VIDEO_VIEW_RATE", :api_name=>"paidVideoViewRate"},
-            {:request_name=>"AVG_CPV", :api_name=>"averageCpv"},
-            {:request_name=>"VIDEO_VIEWS", :api_name=>"videoViews"},
-            {:request_name=>"VIDEO_VIEWS_TO_25", :api_name=>"videoViewsTo25"},
-            {:request_name=>"VIDEO_VIEWS_TO_50", :api_name=>"videoViewsTo50"},
-            {:request_name=>"VIDEO_VIEWS_TO_75", :api_name=>"videoViewsTo75"},
-            {:request_name=>"VIDEO_VIEWS_TO_95", :api_name=>"videoViewsTo95"},
-            {:request_name=>"VIDEO_VIEWS_TO_100", :api_name=>"videoViewsTo100"},
-            {:request_name=>"VIDEO_VIEWS_TO_3_SEC", :api_name=>"videoViewsTo3Sec"},
-            {:request_name=>"VIDEO_VIEWS_TO_10_SEC", :api_name=>"videoViewsTo10Sec"},
-            {:request_name=>"AVG_PERCENT_VIDEO_VIEWED", :api_name=>"averageRateVideoViewed"},
-            {:request_name=>"AVG_DURATION_VIDEO_VIEWED", :api_name=>"averageDurationVideoViewed"},
-            {:request_name=>"IMPRESSION_SHARE", :api_name=>"impressionShare"},
-            {:request_name=>"IMPRESSION_SHARE_BUDGET_LOSS", :api_name=>"budgetImpressionShareLostRate"},
-            {:request_name=>"IMPRESSION_SHARE_RANK_LOSS", :api_name=>"rankImpressionShareLostRate"},
+          { :request_name => "CAMPAIGN_ID", :api_name => "campaignId" },
+          { :request_name => "CAMPAIGN_NAME", :api_name => "campaignName" },
+          { :request_name => "ADGROUP_ID", :api_name => "adGroupId" },
+          { :request_name => "ADGROUP_NAME", :api_name => "adGroupName" },
+          { :request_name => "AD_ID", :api_name => "adId" },
+          { :request_name => "AD_NAME", :api_name => "adName" },
+          { :request_name => "IMPS", :api_name => "imps" },
+          { :request_name => "IMPS_PREV", :api_name => "impsPrev" },
+          { :request_name => "CLICK", :api_name => "clickCnt" },
+          { :request_name => "CLICK_RATE", :api_name => "clickRate" },
+          { :request_name => "CLICK_RATE_PREV", :api_name => "clickRatePrev" },
+          { :request_name => "COST", :api_name => "cost" },
+          { :request_name => "AVG_CPC", :api_name => "avgCpc" },
+          { :request_name => "CONVERSIONS", :api_name => "conversions" },
+          { :request_name => "CONV_RATE", :api_name => "conversionRate" },
+          { :request_name => "CONVERSIONS_VIA_AD_CLICK", :api_name => "conversionsViaAdClick" },
+          { :request_name => "CONVERSION_RATE_VIA_AD_CLICK", :api_name => "conversionRateViaAdClick" },
+          { :request_name => "ALL_CONV", :api_name => "allConversions" },
+          { :request_name => "ALL_CONV_RATE", :api_name => "allConversionRate" },
+          { :request_name => "COST_PER_CONV", :api_name => "cpa" },
+          { :request_name => "CONV_VALUE", :api_name => "conversionValue" },
+          { :request_name => "VALUE_PER_CONV", :api_name => "valuePerConversions" },
+          { :request_name => "CONV_VALUE_PER_COST", :api_name => "convValuePerCost" },
+          { :request_name => "ALL_CONV_VALUE_PER_COST", :api_name => "allConvValuePerCost" },
+          { :request_name => "CONV_VALUE_VIA_AD_CLICK_PER_COST", :api_name => "convValueViaAdClickPerCost" },
+          { :request_name => "ALL_CONV_VALUE", :api_name => "allConversionValue" },
+          { :request_name => "VALUE_PER_ALL_CONV", :api_name => "valuePerAllConversions" },
+          { :request_name => "CONV_VALUE_VIA_AD_CLICK", :api_name => "conversionValueViaAdClick" },
+          { :request_name => "VALUE_PER_CONV_VIA_AD_CLICK", :api_name => "valuePerConversionsViaAdClick" },
+          { :request_name => "COST_PER_CONV_VIA_AD_CLICK", :api_name => "cpaViaAdClick" },
+          { :request_name => "COST_PER_ALL_CONV", :api_name => "allCpa" },
+          { :request_name => "CROSS_DEVICE_CONVERSIONS", :api_name => "crossDeviceConversions" },
+          { :request_name => "AVG_DELIVER_RANK", :api_name => "avgDeliverRank" },
+          { :request_name => "MEASURED_IMPS", :api_name => "measuredImps" },
+          { :request_name => "TOTAL_VIEWABLE_IMPS", :api_name => "totalVimps" },
+          { :request_name => "MEASURED_IMPS_RATE", :api_name => "measuredImpsRate" },
+          { :request_name => "VIEWABLE_IMPS", :api_name => "vimps" },
+          { :request_name => "VIEWABLE_IMPS_RATE", :api_name => "viewableImpsRate" },
+          { :request_name => "INVIEW_RATE", :api_name => "inViewRate" },
+          { :request_name => "VIEWABLE_CLICK", :api_name => "viewableClicks" },
+          { :request_name => "INVIEW_CLICK", :api_name => "inViewClickCnt" },
+          { :request_name => "VIEWABLE_CLICK_RATE", :api_name => "viewableClickRate" },
+          { :request_name => "INVIEW_CLICK_RATE", :api_name => "inViewClickRate" },
+          { :request_name => "PAID_VIDEO_VIEWS", :api_name => "paidVideoViews" },
+          { :request_name => "PAID_VIDEO_VIEW_RATE", :api_name => "paidVideoViewRate" },
+          { :request_name => "AVG_CPV", :api_name => "averageCpv" },
+          { :request_name => "VIDEO_VIEWS", :api_name => "videoViews" },
+          { :request_name => "VIDEO_VIEWS_TO_25", :api_name => "videoViewsTo25" },
+          { :request_name => "VIDEO_VIEWS_TO_50", :api_name => "videoViewsTo50" },
+          { :request_name => "VIDEO_VIEWS_TO_75", :api_name => "videoViewsTo75" },
+          { :request_name => "VIDEO_VIEWS_TO_95", :api_name => "videoViewsTo95" },
+          { :request_name => "VIDEO_VIEWS_TO_100", :api_name => "videoViewsTo100" },
+          { :request_name => "VIDEO_VIEWS_TO_3_SEC", :api_name => "videoViewsTo3Sec" },
+          { :request_name => "VIDEO_VIEWS_TO_10_SEC", :api_name => "videoViewsTo10Sec" },
+          { :request_name => "AVG_PERCENT_VIDEO_VIEWED", :api_name => "averageRateVideoViewed" },
+          { :request_name => "AVG_DURATION_VIDEO_VIEWED", :api_name => "averageDurationVideoViewed" },
+          { :request_name => "IMPRESSION_SHARE", :api_name => "impressionShare" },
+          { :request_name => "IMPRESSION_SHARE_BUDGET_LOSS", :api_name => "budgetImpressionShareLostRate" },
+          { :request_name => "IMPRESSION_SHARE_RANK_LOSS", :api_name => "rankImpressionShareLostRate" },
         ].freeze
 
-        def initialize(servers, account_id, token)
+        def initialize(ads_type, account_id, token)
           super(account_id, token)
-          @base = servers + '/StatsService/'
+          @base = SERVERS[ads_type.to_sym] + "/StatsService/"
         end
 
         def run(query)
           raw_data = []
           get_stats(query, raw_data)
           ::Embulk.logger.info "Get Stats"
-          reshape_data(raw_data,query)
+          reshape_data(raw_data, query)
         end
 
-        def columns(_type=nil)
+        def columns(_type = nil)
           STAT_COLUMNS
         end
 
         private
-        def get_stats(config, raw_data, count=1)
+
+        def get_stats(config, raw_data, count = 1)
           number_result = 1
           get_config = {
             accountId: @account_id,
             statsPeriod: config[:date_range_type],
             periodCustomDate: {
               statsEndDate: config[:end_date],
-              statsStartDate: config[:start_date]
+              statsStartDate: config[:start_date],
             },
             targetTypes: [
-              "GENDER_TARGET"
+              "GENDER_TARGET",
             ],
             type: config[:stats_type],
-            startIndex: (count-1)*number_result+1,
-            numberResults: number_result
+            startIndex: (count - 1) * number_result + 1,
+            numberResults: number_result,
           }.to_json
           response = JSON.parse(self.invoke("get", get_config))
 
-          if response.dig("rval","values").nil?
+          if response.dig("rval", "values").nil?
             raw_data
           else
             if response["rval"]["values"][0]["operationSucceeded"] == false
@@ -108,8 +110,8 @@ module Embulk
               raise ::Embulk::Input::YahooAdsApi::Error::InvalidEnumError, error.to_json
             else
               raw_data.concat(response["rval"]["values"])
-              if response["rval"]["totalNumEntries"] > number_result*count
-                get_stats(config, raw_data, count+1)
+              if response["rval"]["totalNumEntries"] > number_result * count
+                get_stats(config, raw_data, count + 1)
               else
                 raw_data
               end
@@ -117,15 +119,15 @@ module Embulk
           end
         end
 
-        def reshape_data(data,config)
+        def reshape_data(data, config)
           data_type = case config[:stats_type]
-          when 'CAMPAIGN'
-            'campaignStatsValue'
-          when 'ADGROUP'
-            'adGroupStatsValue'
-          when 'AD'
-            'adStatsValue'
-          end
+            when "CAMPAIGN"
+              "campaignStatsValue"
+            when "ADGROUP"
+              "adGroupStatsValue"
+            when "AD"
+              "adStatsValue"
+            end
           data.map do |value|
             stats_info = value[data_type]["stats"]
             value[data_type].delete("stats")

--- a/lib/embulk/input/yahoo_ads_api/version.rb
+++ b/lib/embulk/input/yahoo_ads_api/version.rb
@@ -1,7 +1,7 @@
 module Embulk
   module Input
-      module YahooAdsApi
-        VERSION = "0.2.5.1"
-      end
+    module YahooAdsApi
+      VERSION = "0.2.5.2"
+    end
   end
 end


### PR DESCRIPTION
## プラグインで使用しているAPI

### YSS
- `ReportDefinitionService`

### YDN
- `ReportDefinitionService`
- `StatsService`

## YSSリリースノート

### [v2](https://ads-developers.yahoo.co.jp/developercenter/ja/developers-guide/ysa-v2.html)

#### `ReportDefinitionService`の変更点
- なし

### [v3](https://ads-developers.yahoo.co.jp/developercenter/ja/developers-guide/ysa-v3.html)

#### `ReportDefinitionService`の変更点
- TITLE、DESC、DESCRIPTIONの提供を終了 -> よく分からないが影響なし？

### [v4](https://ads-developers.yahoo.co.jp/developercenter/ja/developers-guide/ysa-v4.html)

#### `ReportDefinitionService`の変更点
- フィルタ条件の項目名の変更 -> 影響なし
- ダウンロードファイルの文字コードを示すEnumで、値の表記「UTF-8」を「UTF8」に変更 -> 対応必要

## YDNリリースノート

### [v2](https://ads-developers.yahoo.co.jp/developercenter/ja/developers-guide/yda-v2.html)

#### `ReportDefinitionService`の変更点
- 「reportDownloadFormat」項目に「TSV」追加 -> 影響なし
- 「reportDownloadEncode」項目に「UTF16LE」を追加 -> 影響なし
- ReportDefinitionオブジェクトの項目名の変更 -> 対応必要
- パフォーマンスレポートの「年齢」項目の一部範囲を変更 -> 年齢の集計範囲が変わるので影響あり。プラグインとして修正点はない

#### `StatsService`の変更点
- viewThroughConversionsの追加 -> 影響なし

### [v3](https://ads-developers.yahoo.co.jp/developercenter/ja/developers-guide/yda_v3.html)

#### `ReportDefinitionService`の変更点
- ReportDefinitionServiceTypeの追加 -> 影響なし
- frequencyRangeの廃止 -> 影響なし

#### `StatsService`の変更点
- なし

### [v4](https://ads-developers.yahoo.co.jp/developercenter/ja/developers-guide/yda-v4.html)

#### `ReportDefinitionService`の変更点
- レポートの「ヘッダ行」「合計行」の有無を指定可能 -> 影響なし
- 小数点を含む数値項目の表示タイプを「全て表示」「簡易表示」から選択可能 -> 影響なし
- 返却する項目名の「動画の平均再生開始率」を「動画の平均再生率」に変更 -> 影響なし
- レポートで返却するキャンペーン掲載タイプの値の表記「E-commerce」を、「Ecommerce」に変更 -> 影響なし
- ダウンロードファイルの文字コードを示すEnumで、値の表記「UTF-8」を「UTF8」に変更 -> 対応必要
- 各種ターゲティングの機能改善 -> 影響なし

#### `StatsService`の変更点
- 動画の再生完了率の取得 -> 影響なし
- 各種ターゲティングの機能改善 -> 影響なし